### PR TITLE
Update to Kotlin 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'babric-loom' version '1.1.+'
+	id 'fabric-loom'
 	id 'org.jetbrains.kotlin.jvm'
 }
 
@@ -8,9 +8,9 @@ archivesBaseName = project.mod_name
 version = project.mod_version
 
 loom {
-	gluedMinecraftJar()
+	// gluedMinecraftJar()
 	noIntermediateMappings()
-	customMinecraftManifest.set("https://github.com/Turnip-Labs/bta-manifest-repo/releases/download/v${project.bta_version}/${project.bta_version}.json")
+	setCustomMinecraftManifest("https://github.com/Turnip-Labs/bta-manifest-repo/releases/download/v${project.bta_version}/${project.bta_version}.json")
 }
 
 repositories {
@@ -97,7 +97,6 @@ dependencies {
 	implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
 	implementation("org.apache.logging.log4j:log4j-1.2-api:${log4jVersion}")
 	include(implementation("org.apache.commons:commons-lang3:3.12.0"))
-
 
 	modImplementation("net.fabricmc:fabric-language-kotlin:${project.flk_version}+kotlin.${project.kotlin_version}") {
 		exclude(group: "net.fabricmc", module: "fabric-loader")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ mod_menu_version=2.0.6
 halplibe_version=4.1.3
 
 # Fabric Language Kotlin
-flk_version=1.9.4
-kotlin_version=1.8.21
+flk_version=1.11.0
+kotlin_version=2.0.0
 
 # Mod
 mod_version=1.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ pluginManagement {
     }
 
     plugins {
-        id 'babric-loom' version '1.1.+'
+        id 'fabric-loom' version '1.7-SNAPSHOT'
         id "org.jetbrains.kotlin.jvm" version kotlin_version
     }
 }

--- a/src/main/kotlin/turniplabs/examplemod/ExampleMod.kt
+++ b/src/main/kotlin/turniplabs/examplemod/ExampleMod.kt
@@ -7,19 +7,18 @@ import turniplabs.halplibe.util.GameStartEntrypoint
 import turniplabs.halplibe.util.RecipeEntrypoint
 
 object ExampleMod: ModInitializer, GameStartEntrypoint, RecipeEntrypoint {
-    @JvmField
-    val MODID: String = "examplemod"
+	const val MODID: String = "examplemod"
 
-    @JvmField
-    val LOGGER: Logger = LoggerFactory.getLogger(MODID)
+	@JvmField
+	val LOGGER: Logger = LoggerFactory.getLogger(MODID)
 
-    override fun onInitialize() {
+	override fun onInitialize() {
         // This code runs as soon as Minecraft is in a mod-load-ready state.
         // However, some things (like resources) may still be uninitialized.
         // Proceed with mild caution.
 
-        LOGGER.info("Hello Fabric world!")
-    }
+		LOGGER.info("Hello Fabric world!")
+	}
 
 	override fun beforeGameStart() {
 
@@ -36,5 +35,4 @@ object ExampleMod: ModInitializer, GameStartEntrypoint, RecipeEntrypoint {
 	override fun initNamespaces() {
 
 	}
-
 }


### PR DESCRIPTION
Also switched to official Loom with the version 1.7 as Loom versions prior to 1.3 would not recognize the Kotlin version correctly and the official Loom has supported merging pre-1.3 clients and servers. This also results in a bump of Gradle version from 7.5 to 8.8. I guess other example mods need updating too?

Otherwise there should be no big changes. Note that this would probably require newer IDEA as I'm not quite sure about K2 compatibility in legacy IDEA versions.