### PR TITLE
Fixed incorrect natives being applied on Apple Silicon macs.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ val lwjglVersion = "3.3.4"
 val lwjglNatives = when {
     Os.isFamily(Os.FAMILY_UNIX) && !Os.isFamily(Os.FAMILY_MAC) -> "natives-linux"
     Os.isFamily(Os.FAMILY_WINDOWS) -> "natives-windows"
-    Os.isFamily(Os.FAMILY_MAC) -> "natives-macos"
+    Os.isFamily(Os.FAMILY_MAC) -> "natives-macos${if (Os.isArch("aarch64")) "-arm64" else ""}"
     else -> error("Unsupported OS")
 }
 


### PR DESCRIPTION
Brings bta-example-mod-kotlin inline with bta-example-mod in fixing issue, original fix this from [this commit](https://github.com/Turnip-Labs/bta-example-mod/commit/6f202b8)